### PR TITLE
Wrong reference in production

### DIFF
--- a/AnimateAsset.php
+++ b/AnimateAsset.php
@@ -8,7 +8,7 @@ class AnimateAsset extends AssetBundle{
     
     public $sourcePath = '@bower/animate.css';
     public function init(){
-        $this->css[] = YII_DEBUG ? 'animate.css' : 'animate.min.js';
+        $this->css[] = YII_DEBUG ? 'animate.css' : 'animate.min.css';
         parent::init();
     }
 }


### PR DESCRIPTION
When in production the Bundle search for `animate.min.js` which does not exist.
